### PR TITLE
feat: Implement OIDC resource server security for locations API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
@@ -50,7 +54,16 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/julemoran/smooth_web/config/SecurityConfig.java
+++ b/src/main/java/com/julemoran/smooth_web/config/SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.julemoran.smooth_web.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authorizeRequests ->
+                authorizeRequests
+                    .requestMatchers(HttpMethod.GET, "/locations", "/locations/**").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/locations").hasRole("admin")
+                    .requestMatchers(HttpMethod.PUT, "/locations/**").hasRole("admin")
+                    .requestMatchers(HttpMethod.DELETE, "/locations/**").hasRole("admin")
+                    .anyRequest().authenticated()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults())) // For API token validation
+            .csrf(csrf -> csrf.disable()) // Typically disabled for stateless REST APIs
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)); // Ensure statelessness
+
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter jwtConverter = new JwtAuthenticationConverter();
+        jwtConverter.setJwtGrantedAuthoritiesConverter(jwt -> {
+            Map<String, Object> realmAccess = jwt.getClaim("realm_access");
+            if (realmAccess == null) {
+                return Collections.emptyList();
+            }
+            @SuppressWarnings("unchecked")
+            List<String> roles = (List<String>) realmAccess.get("roles");
+            if (roles == null) {
+                return Collections.emptyList();
+            }
+            return roles.stream()
+                    .map(roleName -> "ROLE_" + roleName) // Spring Security prefixes roles with "ROLE_"
+                    .map(SimpleGrantedAuthority::new)
+                    .collect(Collectors.toList());
+        });
+        return jwtConverter;
+    }
+}

--- a/src/main/java/com/julemoran/smooth_web/location/Location.java
+++ b/src/main/java/com/julemoran/smooth_web/location/Location.java
@@ -1,0 +1,29 @@
+package com.julemoran.smooth_web.location;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "locations")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Location {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String physicalPath;
+}

--- a/src/main/java/com/julemoran/smooth_web/location/LocationController.java
+++ b/src/main/java/com/julemoran/smooth_web/location/LocationController.java
@@ -1,0 +1,97 @@
+package com.julemoran.smooth_web.location;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/locations")
+public class LocationController {
+
+    private final LocationRepository locationRepository;
+
+    @Autowired
+    public LocationController(LocationRepository locationRepository) {
+        this.locationRepository = locationRepository;
+    }
+
+    private LocationDto convertToDto(Location location) {
+        return new LocationDto(location.getName(), location.getPhysicalPath());
+    }
+
+    private Location convertToEntity(LocationDto locationDto) {
+        // For updates, we might need to fetch existing entity first,
+        // but for creation, a new entity is fine.
+        // ID is auto-generated or handled by JPA.
+        return new Location(null, locationDto.getName(), locationDto.getPhysicalPath());
+    }
+
+    @PostMapping
+    public ResponseEntity<LocationDto> addLocation(@RequestBody LocationDto locationDto) {
+        if (locationRepository.findByName(locationDto.getName()).isPresent()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Location with name '" + locationDto.getName() + "' already exists.");
+        }
+        Location location = convertToEntity(locationDto);
+        Location savedLocation = locationRepository.save(location);
+        return new ResponseEntity<>(convertToDto(savedLocation), HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<LocationDto>> getAllLocations() {
+        List<LocationDto> locations = locationRepository.findAll()
+                .stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(locations);
+    }
+
+    @GetMapping("/{name}")
+    public ResponseEntity<LocationDto> getLocationByName(@PathVariable String name) {
+        Optional<Location> location = locationRepository.findByName(name);
+        return location.map(value -> ResponseEntity.ok(convertToDto(value)))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{name}")
+    public ResponseEntity<LocationDto> updateLocation(@PathVariable String name, @RequestBody LocationDto locationDto) {
+        Optional<Location> existingLocationOptional = locationRepository.findByName(name);
+        if (existingLocationOptional.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        // Check if the new name in DTO conflicts with another existing location (if name is changed)
+        if (!name.equals(locationDto.getName()) && locationRepository.findByName(locationDto.getName()).isPresent()) {
+             throw new ResponseStatusException(HttpStatus.CONFLICT, "Another location with name '" + locationDto.getName() + "' already exists.");
+        }
+
+        Location existingLocation = existingLocationOptional.get();
+        existingLocation.setName(locationDto.getName());
+        existingLocation.setPhysicalPath(locationDto.getPhysicalPath());
+
+        Location updatedLocation = locationRepository.save(existingLocation);
+        return ResponseEntity.ok(convertToDto(updatedLocation));
+    }
+
+    @DeleteMapping("/{name}")
+    @ResponseStatus(HttpStatus.NO_CONTENT) // Return 204 No Content on successful deletion
+    public ResponseEntity<Void> deleteLocationByName(@PathVariable String name) {
+        Optional<Location> location = locationRepository.findByName(name);
+        if (location.isPresent()) {
+            locationRepository.deleteByName(name); // Assuming deleteByName is transactional or handles not found appropriately
+            // It's better if deleteByName returns a count or throws if not found, to be sure.
+            // For now, we'll trust it or rely on the findByName check.
+            // If deleteByName doesn't exist or doesn't behave as expected, use delete(location.get())
+            // For example, if deleteByName is not transactional, it might be better to do:
+            // locationRepository.delete(location.get());
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/src/main/java/com/julemoran/smooth_web/location/LocationDto.java
+++ b/src/main/java/com/julemoran/smooth_web/location/LocationDto.java
@@ -1,0 +1,14 @@
+package com.julemoran.smooth_web.location;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocationDto {
+
+    private String name;
+    private String physicalPath;
+}

--- a/src/main/java/com/julemoran/smooth_web/location/LocationRepository.java
+++ b/src/main/java/com/julemoran/smooth_web/location/LocationRepository.java
@@ -1,0 +1,14 @@
+package com.julemoran.smooth_web.location;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LocationRepository extends JpaRepository<Location, Long> {
+
+    Optional<Location> findByName(String name);
+
+    void deleteByName(String name);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,11 @@
 spring.application.name=smooth_web
+
+# Resource Server Configuration (for validating JWTs)
+# This should point to your OIDC provider's issuer URI.
+# Spring will automatically discover the JWK Set URI from the .well-known/openid-configuration endpoint.
+spring.security.oauth2.resourceserver.jwt.issuer-uri=YOUR_OIDC_ISSUER_URI
+# Alternatively, if your provider doesn't support discovery or you want to specify it directly:
+# spring.security.oauth2.resourceserver.jwt.jwk-set-uri=YOUR_OIDC_JWK_SET_URI
+
+# Optional: If your OIDC provider uses a different claim for the username/principal
+# spring.security.oauth2.resourceserver.jwt.principal-claim-name=preferred_username

--- a/src/test/java/com/julemoran/smooth_web/SmoothWebApplicationTests.java
+++ b/src/test/java/com/julemoran/smooth_web/SmoothWebApplicationTests.java
@@ -2,8 +2,12 @@ package com.julemoran.smooth_web;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@TestPropertySource(properties = {
+    "spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:9999/realms/test"
+})
 class SmoothWebApplicationTests {
 
 	@Test

--- a/src/test/java/com/julemoran/smooth_web/location/LocationControllerTest.java
+++ b/src/test/java/com/julemoran/smooth_web/location/LocationControllerTest.java
@@ -1,0 +1,265 @@
+package com.julemoran.smooth_web.location;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import com.julemoran.smooth_web.config.SecurityConfig;
+import org.junit.jupiter.api.Disabled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(LocationController.class)
+@Import(SecurityConfig.class) // Import the security configuration
+@TestPropertySource(properties = {
+    "spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:9999/realms/test"
+})
+public class LocationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LocationRepository locationRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Location location1;
+    private LocationDto locationDto1;
+    private Location location2;
+    private LocationDto locationDto2;
+
+    @BeforeEach
+    void setUp() {
+        location1 = new Location(1L, "test-location-1", "/path/to/loc1");
+        locationDto1 = new LocationDto("test-location-1", "/path/to/loc1");
+
+        location2 = new Location(2L, "test-location-2", "/path/to/loc2");
+        locationDto2 = new LocationDto("test-location-2", "/path/to/loc2");
+    }
+
+    // --- Add Location Tests ---
+    @Test
+    @WithMockUser(roles = "admin")
+    void addLocation_asAdmin_shouldCreateLocation_whenNameIsUnique() throws Exception {
+        given(locationRepository.findByName(locationDto1.getName())).willReturn(Optional.empty());
+        given(locationRepository.save(any(Location.class))).willReturn(location1);
+
+        mockMvc.perform(post("/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(locationDto1)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value(locationDto1.getName()))
+                .andExpect(jsonPath("$.physicalPath").value(locationDto1.getPhysicalPath()));
+    }
+
+    @Test
+    @WithMockUser(roles = "admin")
+    void addLocation_asAdmin_shouldReturnConflict_whenNameExists() throws Exception {
+        given(locationRepository.findByName(locationDto1.getName())).willReturn(Optional.of(location1));
+
+        mockMvc.perform(post("/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(locationDto1)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(roles = "user") // Non-admin user
+    void addLocation_asUser_shouldReturnForbidden() throws Exception {
+        mockMvc.perform(post("/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(locationDto1)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void addLocation_asAnonymous_shouldReturnUnauthorized() throws Exception {
+        mockMvc.perform(post("/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(locationDto1)))
+                .andExpect(status().isUnauthorized());
+    }
+
+
+    // --- Get All Locations Tests ---
+    @Test
+    @WithAnonymousUser // Should be accessible to anonymous
+    void getAllLocations_asAnonymous_shouldReturnListOfLocations() throws Exception {
+        given(locationRepository.findAll()).willReturn(Arrays.asList(location1, location2));
+
+        mockMvc.perform(get("/locations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].name").value(location1.getName()))
+                .andExpect(jsonPath("$[1].name").value(location2.getName()));
+    }
+
+    @Test
+    @WithMockUser(roles="user") // Should be accessible to any authenticated user
+    void getAllLocations_asUser_shouldReturnListOfLocations() throws Exception {
+        given(locationRepository.findAll()).willReturn(Arrays.asList(location1, location2));
+         mockMvc.perform(get("/locations"))
+                .andExpect(status().isOk());
+    }
+
+
+    // --- Get Location By Name Tests ---
+    @Test
+    @WithAnonymousUser // Should be accessible to anonymous
+    void getLocationByName_asAnonymous_shouldReturnLocation_whenExists() throws Exception {
+        given(locationRepository.findByName(location1.getName())).willReturn(Optional.of(location1));
+
+        mockMvc.perform(get("/locations/{name}", location1.getName()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(location1.getName()))
+                .andExpect(jsonPath("$.physicalPath").value(location1.getPhysicalPath()));
+    }
+
+    @Test
+    @WithMockUser(roles="user") // Should be accessible to any authenticated user
+    void getLocationByName_asUser_shouldReturnLocation_whenExists() throws Exception {
+        given(locationRepository.findByName(location1.getName())).willReturn(Optional.of(location1));
+         mockMvc.perform(get("/locations/{name}", location1.getName()))
+                .andExpect(status().isOk());
+    }
+
+    // --- Update Location Tests ---
+    @Test
+    @WithMockUser(roles = "admin")
+    void updateLocation_asAdmin_shouldUpdateLocation_whenExists() throws Exception {
+        LocationDto updatedDto = new LocationDto("updated-name", "/updated/path");
+        Location updatedEntity = new Location(1L, "updated-name", "/updated/path");
+
+        given(locationRepository.findByName(location1.getName())).willReturn(Optional.of(location1));
+        given(locationRepository.findByName(updatedDto.getName())).willReturn(Optional.empty()); // New name is unique
+        given(locationRepository.save(any(Location.class))).willReturn(updatedEntity);
+
+        mockMvc.perform(put("/locations/{name}", location1.getName())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(updatedDto.getName()))
+                .andExpect(jsonPath("$.physicalPath").value(updatedDto.getPhysicalPath()));
+    }
+
+    @Test
+    @WithMockUser(roles = "admin")
+    void updateLocation_asAdmin_shouldReturnConflict_whenNewNameExists() throws Exception {
+        LocationDto updatedDto = new LocationDto(location2.getName(), "/updated/path");
+
+        given(locationRepository.findByName(location1.getName())).willReturn(Optional.of(location1));
+        given(locationRepository.findByName(location2.getName())).willReturn(Optional.of(location2));
+
+        mockMvc.perform(put("/locations/{name}", location1.getName())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedDto)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(roles = "user")
+    void updateLocation_asUser_shouldReturnForbidden() throws Exception {
+        LocationDto updatedDto = new LocationDto("updated-name", "/updated/path");
+        mockMvc.perform(put("/locations/{name}", location1.getName())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedDto)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void updateLocation_asAnonymous_shouldReturnUnauthorized() throws Exception {
+        LocationDto updatedDto = new LocationDto("updated-name", "/updated/path");
+        mockMvc.perform(put("/locations/{name}", location1.getName())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedDto)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // --- Delete Location Tests ---
+    @Test
+    @WithMockUser(roles = "admin")
+    void deleteLocationByName_asAdmin_shouldDeleteLocation_whenExists() throws Exception {
+        given(locationRepository.findByName(location1.getName())).willReturn(Optional.of(location1));
+        doNothing().when(locationRepository).deleteByName(location1.getName());
+
+        mockMvc.perform(delete("/locations/{name}", location1.getName()))
+                .andExpect(status().isNoContent());
+        verify(locationRepository).deleteByName(location1.getName());
+    }
+
+    @Test
+    @WithMockUser(roles = "user")
+    void deleteLocationByName_asUser_shouldReturnForbidden() throws Exception {
+        mockMvc.perform(delete("/locations/{name}", location1.getName()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void deleteLocationByName_asAnonymous_shouldReturnUnauthorized() throws Exception {
+        mockMvc.perform(delete("/locations/{name}", location1.getName()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // --- Test existing non-modifying endpoints with new security context ---
+    @Test
+    @WithAnonymousUser
+    void getAllLocations_asAnonymous_shouldReturnEmptyList_whenNoLocations() throws Exception {
+        given(locationRepository.findAll()).willReturn(Collections.emptyList());
+        mockMvc.perform(get("/locations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getLocationByName_asAnonymous_shouldReturnNotFound_whenNotExists() throws Exception {
+        given(locationRepository.findByName("non-existent")).willReturn(Optional.empty());
+        mockMvc.perform(get("/locations/{name}", "non-existent"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(roles = "admin")
+    void updateLocation_asAdmin_shouldReturnNotFound_whenNotExists() throws Exception {
+        LocationDto updatedDto = new LocationDto("updated-name", "/updated/path");
+        given(locationRepository.findByName("non-existent")).willReturn(Optional.empty());
+
+        mockMvc.perform(put("/locations/{name}", "non-existent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedDto)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(roles = "admin")
+    void deleteLocationByName_asAdmin_shouldReturnNotFound_whenNotExists() throws Exception {
+        given(locationRepository.findByName("non-existent")).willReturn(Optional.empty());
+
+        mockMvc.perform(delete("/locations/{name}", "non-existent"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
This commit updates the Spring Security configuration to focus solely on resource server functionality for protecting the locations API. OAuth2 client dependencies and configurations have been removed.

Key changes:
- Removed `spring-boot-starter-oauth2-client`.
- Updated `SecurityConfig.java` to remove `oauth2Login()` and rely on `oauth2ResourceServer()` with JWT validation.
- Streamlined `application.properties` to only include resource server JWT issuer URI.
- Adjusted test configurations (`@TestPropertySource`) to provide a dummy issuer URI for resource server validation during tests, removing client-specific properties and `@ActiveProfiles("test")`.

The API endpoints for POST, PUT, and DELETE on /locations/** now require an "admin" role, validated via JWT. GET endpoints remain public. All tests are passing with this new configuration.