### PR TITLE
feat: configure vite proxy and backend port

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 spring.application.name=smooth_web
 spring.config.import=optional:file:./deployment_parameters.yaml
 
+server.port=8085
+
 # Resource Server Configuration (for validating JWTs)
 # This should point to your OIDC provider's issuer URI.
 # Spring will automatically discover the JWK Set URI from the .well-known/openid-configuration endpoint.

--- a/src/main/ui/vite.config.ts
+++ b/src/main/ui/vite.config.ts
@@ -15,4 +15,12 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8085',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
- Added proxy to vite.config.ts to forward /api requests to http://localhost:8085.
- Set server.port=8085 in application.properties.